### PR TITLE
Allow template literals as quoted strings.

### DIFF
--- a/index.js
+++ b/index.js
@@ -153,8 +153,8 @@ module.exports = {
 		// Only quote properties when necessary for any of them
 		'quote-props': ['warn', 'consistent-as-needed'],
 
-		// Use single quotes
-		'quotes': ['warn', 'single'],
+		// Use single quotes, but allow for template literals when necessary
+		'quotes': ['warn', 'single', { 'allowTemplateLiterals': true }],
 
 		// Never depend on automatic semicolon insertion
 		'semi': ['warn', 'always'],


### PR DESCRIPTION
But keep single quotes as the default, just allow template literals when they are necessary.
See http://eslint.org/docs/rules/quotes