### PR TITLE
Make this plugin npm compatible with eslint 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/FontoXML/eslint-config-fontoxml.git"
   },
   "peerDependencies": {
-    "eslint": "^3.9.0",
-    "eslint-plugin-react": "^6.7.1"
+    "eslint": "^3.9.0 || ^4.0.0",
+    "eslint-plugin-react": "^6.7.1 || ^7.0.0"
   }
 }


### PR DESCRIPTION
Add the eslint and eslint-plugin-react version ranges that we use in fontoxml-vendor-fds which uses eslint 4.
This prevents annoying NPM warnings.

Eslint 4 introduces new rules that we could take advantage of, but it's not immediately necessary to do so.