### PR TITLE
DEV-3131 Disallow shadowed variables.

### DIFF
--- a/base.js
+++ b/base.js
@@ -58,12 +58,11 @@ module.exports = {
 		// Easy enough to hide using higher-order functions, but still usually a code smell that can be avoided
 		'no-loop-func': 'warn',
 
-		// Shadowing is ok, and can improve clarity (e.g., in a reduce)
-		// (default from eslint:recommended)
-		// 'no-shadow': 'off',
-
 		// Disallow the following global variables
 		'no-restricted-globals': ['error', 'document', 'error', 'event', 'fdescribe', 'status'],
+
+		// Shadowing variables currently may cause issues in Fonto's build tools
+		'no-shadow': ['error', { builtinGlobals: true, hoist: 'all', allow: [] }],
 
 		// But shadowing of things like NaN or undefined is just stupid
 		'no-shadow-restricted-names': 'error',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@fontoxml/eslint-config",
-  "version": "3.1.1",
+  "version": "3.2.1",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fontoxml/eslint-config",
-  "version": "3.1.1",
+  "version": "3.2.1",
   "description": "ESLint configuration for FontoXML platform and projects",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The main reason for this change is webpack having issues with shadowed imported variables. Once that's been resolved we can consider reverting this change, although variable shadowing is commonly regarded as a bad practice anyway.