### PR TITLE
Allow shadowing globals again

### DIFF
--- a/base.js
+++ b/base.js
@@ -61,8 +61,8 @@ module.exports = {
 		// Disallow the following global variables
 		'no-restricted-globals': ['error', 'document', 'error', 'event', 'fdescribe', 'status'],
 
-		// Shadowing variables currently may cause issues in Fonto's build tools
-		'no-shadow': ['error', { builtinGlobals: true, hoist: 'all', allow: [] }],
+		// Shadowing is usually bad practice and causes confusing code
+		'no-shadow': ['warn', { builtinGlobals: false, hoist: 'all', allow: [] }],
 
 		// But shadowing of things like NaN or undefined is just stupid
 		'no-shadow-restricted-names': 'error',


### PR DESCRIPTION
What is wrong with this code?

```
const context = {
 something: 123
};
```

Answer: The configuration of before this commit marked `context` as
shadowing something.

It appears that `context` is also present on window. The same is for
globals like `origin`, `top`, and other useful variable names. We
should be able to do that.