### PR TITLE
Warn for usages of 'var'

### DIFF
--- a/base.js
+++ b/base.js
@@ -89,6 +89,9 @@ module.exports = {
 		// Using 'with' only obfuscates code
 		'no-with': 'error',
 
+		// Prefer anything but 'var'
+		'no-var': 'warn',
+
 		// Prefer const instead of let if a variable is not reassigned
 		'prefer-const': 'error',
 


### PR DESCRIPTION
In ES6, there is no use case for 'var', only 'let' and 'const' are good.

This will generate a lot of warnings though, but they should be easy to fix.