### PR TITLE
Fix eslint version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ ESLint and prettier configuration for Fonto platform and projects.
 Install eslint and the Fonto configuration package:
 
 ```
-npm i -g babel-eslint eslint @fontoxml/eslint-config eslint-config-prettier eslint-plugin-prettier eslint-plugin-react prettier
+npm i -g babel-eslint eslint@5.16.0 @fontoxml/eslint-config eslint-config-prettier eslint-plugin-prettier eslint-plugin-react prettier
 ```
 
 Create an `.eslintrc` file extending the Fonto configuration somewhere in your project folder or in an ancestor:


### PR DESCRIPTION
For some reason, we are not compatible with eslint@latest. Running the mentioned command will result in a broken install. We should fix it later, but at least make it work now.