### PR TITLE
Turn off "no-shadow" rule

### DIFF
--- a/rules/base.js
+++ b/rules/base.js
@@ -109,10 +109,7 @@ module.exports = {
 		'no-script-url': 'error',
 		'no-self-compare': 'error',
 		'no-sequences': 'error',
-		'no-shadow': [
-			'warn',
-			{ builtinGlobals: false, hoist: 'all', allow: [] },
-		],
+		'no-shadow': 'off',
 		'no-template-curly-in-string': 'off', // @TODO
 		'no-ternary': 'off', // @TODO
 		'no-throw-literal': 'off',


### PR DESCRIPTION
Shadowing is usually fine, and can be a useful tool to prevent accidentally accessing a variable in an outer scope when the inner scope version should be used.